### PR TITLE
Ignore TypeScript Errors

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,9 @@ export default class ToggleReadableLineLengthPlugin extends Plugin {
 			name: 'Toggle Readable line length',
 			editorCallback: (editor: Editor, view: MarkdownView) => {
 				console.log("Toggle Readable line length");
+				// @ts-ignore
 				const optionEnabled = this.app.vault.getConfig("readableLineLength");
+				// @ts-ignore
 				this.app.vault.setConfig("readableLineLength", !optionEnabled);
 			}
 		});


### PR DESCRIPTION
Getting the following error in the release.yaml GitHub Action. Can reproduce it locally with `npx tsc` as well.

```
Error: main.ts(10,42): error TS2339: Property 'getConfig' does not exist on type 'Vault'.
Error: main.ts(11,20): error TS2339: Property 'setConfig' does not exist on type 'Vault'.
Error: Process completed with exit code 2.
```

`setConfig`/`getConfig` are not part of the Vault's TypeScript API. However, they do exist, so adding typescript ignores.

This likely means the Obsidian team may break this mechanism at any time.